### PR TITLE
Fix EMBED_COLOR and APIChecker.logger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,4 +13,4 @@ API_URL=''
 
 ## Bot configuration
 REFRESH_DELAY=         # in minutes!
-EMBED_COLOR=0xffb7c5   # must be an int (hexa is accepted)
+EMBED_COLOR=0xffb7c5   # must be an int (hexa only, RGB)

--- a/blogReader.py
+++ b/blogReader.py
@@ -5,7 +5,7 @@ import logging
 
 BLOG_URL = getenv('BLOG_URL')
 API_URL = getenv('API_URL')
-EMBED_COLOR = int(getenv('EMBED_COLOR') or 0xffb7c5)
+EMBED_COLOR = int(getenv('EMBED_COLOR') or "0xffb7c5", base=16)
 
 class APIChecker:
 

--- a/blogReader.py
+++ b/blogReader.py
@@ -14,9 +14,9 @@ class APIChecker:
         self.url = API_URL
         self.__cache = []
         self.__new = []
+        self.logger = logging.getLogger(__name__)
         self.__getArticles()
         self.__cacheArticlesID()
-        self.logger = logging.getLogger(__name__)
 
     def __getArticles(self):
         if self.__cache == []:


### PR DESCRIPTION
Fixes issues with #6 and #8 :
- Embed_color could not be interpreted as an hexadecimal integer. 3480413
- The APIChecker logger was defined after being used. 680a847